### PR TITLE
Add scraped page archive

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -3,11 +3,11 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
-require 'open-uri'
 require 'scraperwiki'
 
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko_for(url)
   Nokogiri::HTML(open(url).read)


### PR DESCRIPTION
Mentioned in issue: https://github.com/everypolitician/everypolitician-data/issues/20544

Adds scraped page archive.

# Scraper change checklist

* [ ] ~~scraper is on Morph.io under the "everypolitician-scrapers" group~~
* [x] scraper's GitHub "Website" link points at morph.io page
* [x] scraper is set to auto-run
* [x] scraper is archiving _(unless source doesn't require that)_

# Scraped page archive

* [x] scraper uses scraped archive gem (unless upstream source has its own archive)
* [x] repo URL uses `https` not `git@` (until [#37 is solved](https://github.com/everypolitician/scraped_page_archive/issues/37)) 
* [x] all gemfile links are secure (e.g., use https)
* [ ] morph is configured to write to GitHub ("secret" environment vars)
@tmtmtmtm The scraper's ENV variables need configuring on Morph.
* [x] pages are archived in new branch of correct scraper repo (yay!)

### Gemfile change:
* [x] all links are secure
* [x] links to Github use `github:` protocol, not simply `git:`
* [x] formatting is consistent with our normal Rubocop setup